### PR TITLE
Add ledger check to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@ An express middleware adding SEP-8 compliance to your project by specifying your
 
 ## Usage
 
-See the [example](/example/index.js) project for a full implementation that implements a simple "Transaction must be less than an amount of 50" ruleset.
+See the [example](/example/index.js) project for a full implementation that implements a simple "Transaction must be less than an amount of 50, and accounts can hold a maximum of 1000 tokens" ruleset.
 
 ### Env Vars
 
 Add `ASSET_CODE` and `ISSUER_SECRET` environment variables so that the bridge can sign approval transactions.
+`BRIDGE_HOSTNAME` is required if you use the TOML middleware, and should contain the hostname the approval server will be located at.
 
 ### Implementation
 

--- a/bridge/approve.js
+++ b/bridge/approve.js
@@ -56,7 +56,16 @@ module.exports = function (rules) {
       fee: feeStats.fee_charged.p90,
       networkPassphrase: StellarSdk.Networks.TESTNET,
     });
-
+    let assetsToParticipantMap = {};
+    tx.operations.forEach((operation) => {
+      if (operation.type === "payment") {
+        const code = operation.asset.getCode();
+        assetsToParticipantMap[code] =
+          assetsToParticipantMap[code] || new Set();
+        assetsToParticipantMap[code].add(operation.source || tx.source);
+        assetsToParticipantMap[code].add(operation.destination);
+      }
+    });
     const setParticipantAuthorizations = (allow) => {
       Object.keys(assetsToParticipantMap).forEach((asset) => {
         const participants = assetsToParticipantMap[asset];


### PR DESCRIPTION
The current example rule was too simple.  I added a rule "Accounts can not hold more than 1000 tokens" so we need to check the ledger from horizon which exercises and illustrates both checking the ledger and doing asynchronous things in the rule.

I also filter out any transactions that don't contain 1 and only 1 payment operation.  There is still a problem that other operations could sneak in, but i have a bug filed for that in #4 .

Fixes #2 